### PR TITLE
Add additional plugins to settings configuration

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,6 +1,13 @@
 {
   "enabledPlugins": {
     "skill-creator@claude-plugins-official": true,
-    "context7@claude-plugins-official": true
+    "context7@claude-plugins-official": true,
+    "security-guidance@claude-plugins-official": true,
+    "code-review@claude-plugins-official": true,
+    "github@claude-plugins-official": true,
+    "pr-review-toolkit@claude-plugins-official": true,
+    "feature-dev@claude-plugins-official": true,
+    "kotlin-lsp@claude-plugins-official": true,
+    "figma@claude-plugins-official": true
   }
 }

--- a/.gitignore
+++ b/.gitignore
@@ -36,6 +36,7 @@ deploymentTargetSelector.xml
 render.experimental.xml
 !/.idea/scopes
 !/.idea/.name
+!/.idea/dictionaries
 
 # Keystore files
 *.jks

--- a/.idea/dictionaries/project.xml
+++ b/.idea/dictionaries/project.xml
@@ -1,0 +1,7 @@
+<component name="ProjectDictionaryState">
+  <dictionary name="project">
+    <words>
+      <w>figma</w>
+    </words>
+  </dictionary>
+</component>


### PR DESCRIPTION
This pull request updates project configuration files to enable additional plugins and improve code assistance. The main changes are the addition of several official Claude plugins for enhanced development workflows and the inclusion of "figma" in the project dictionary for spellchecking support.

**Plugin configuration updates:**

* Enabled several new Claude official plugins in `.claude/settings.json`, including `security-guidance`, `code-review`, `github`, `pr-review-toolkit`, `feature-dev`, `kotlin-lsp`, and `figma`, to support security, code review, GitHub integration, feature development, Kotlin language server, and Figma integration.

**IDE/editor improvements:**

* Added the word "figma" to the project dictionary in `.idea/dictionaries/project.xml` to prevent it from being flagged as a spelling error.